### PR TITLE
Add kotlinx-serialization-json to headless

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ minSdk = "26"
 compileSdk = "35"
 jvmTarget = "18"
 
-corioDependencies = "2026-05-05" # YYYY-MM-dd
+corioDependencies = "2026-07-06" # YYYY-MM-dd
 
 camera = "1.4.1"
 core-ktx = "1.15.0"
@@ -27,6 +27,7 @@ glide = "5.0.5"
 exoplayer = "1.9.2"
 commonmark = "0.24.0"
 junit = "4.13.2"
+kotlinx-serialization = "1.7.3"
 
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
@@ -54,6 +55,7 @@ dots-indicator = { group = "com.tbuonomo", name = "dotsindicator", version.ref =
 lottie = { group = "com.airbnb.android", name = "lottie", version.ref = "lottie" }
 sentry-android = { module = "io.sentry:sentry-android", version.ref = "sentry-android-version" }
 commonmark = { group = "org.commonmark", name = "commonmark", version.ref = "commonmark" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 
 # Test Libraries
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -65,4 +67,5 @@ exoplayer = ["exoplayer-core", "exoplayer-ui"]
 [plugins]
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 

--- a/headless/build.gradle.kts
+++ b/headless/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.serialization)
     id("maven-publish")
 }
 
@@ -36,6 +37,7 @@ dependencies {
     api(libs.coroutines.core)
     api(libs.bundles.camera)
     api(libs.sentry.android)
+    api(libs.kotlinx.serialization.json)
 
     api(libs.activity.ktx)
 }


### PR DESCRIPTION
## Summary
- Adds `kotlinx-serialization-json` (1.7.3) as an `api` dependency of the `headless` module, plus the `kotlin.serialization` Gradle plugin.
- Bumps `corioDependencies` to `2026-07-06`.

## Why
[sdk-android PR #247](https://github.com/corio-health/sdk-android/pull/247) (DEV-3917) adds typed, `kotlinx.serialization`-based convenience accessors on top of the questionnaire API in `headless-api`. That dependency was temporarily added directly in `sdk-android`'s `headless-api/build.gradle.kts` as a stopgap, with a note that it should instead be routed through this repo per `sdk-android`'s `CLAUDE.md` dependency policy. This PR does that.

Once merged, a `2026-07-06` tag will be cut here so JitPack can publish it, and `sdk-android` will be updated to consume `kotlinx-serialization-json` transitively via `corio-headless` instead of adding it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)